### PR TITLE
Propagate maven.settings to the tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,4 +50,4 @@ jobs:
           key: maven-repo-${{ runner.os }}-${{ steps.get-date.outputs.date }}
 
       - name: Build with Maven
-        run: mvn -B formatter:validate verify --file pom.xml -Dnative
+        run: mvn -B formatter:validate install --file pom.xml -Dnative

--- a/deployment/src/main/java/io/quarkiverse/renarde/deployment/RenardeProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/renarde/deployment/RenardeProcessor.java
@@ -310,12 +310,12 @@ public class RenardeProcessor {
         /*
          * @RequestScoped
          * public class MySecurity {
-         * 
+         *
          * @Inject
          * RenardeSecurity security;
-         * 
+         *
          * @Named("user")
-         * 
+         *
          * @Produces
          * public User getUser() {
          * return (User) security.getUser();
@@ -566,7 +566,7 @@ public class RenardeProcessor {
         if (controllers.contains(method.declaringClass().name())) {
             /*
              * @Path("foo") class Class { @Path("bar") method(); } -> no change
-             * 
+             *
              * @Path("foo") class Class { method(); } -> @Path("foo") class Class { @Path("method") method(); }
              * class Class { @Path("/bar") method(); } -> @Path("") class Class { @Path("/bar") method(); }
              * class Class { @Path("bar") method(); } -> @Path("") class Class { @Path("Class/bar") method(); }

--- a/oidc-tests/src/main/java/io/quarkiverse/renarde/oidc/test/MockAppleOidcTestResource.java
+++ b/oidc-tests/src/main/java/io/quarkiverse/renarde/oidc/test/MockAppleOidcTestResource.java
@@ -123,7 +123,7 @@ public class MockAppleOidcTestResource extends MockOidcTestResource<MockAppleOid
      * GET
      * https://appleid.apple.com/auth/authorize?response_type=code&client_id=CLIENT&scope=openid+openid+email+name&redirect_uri=
      * https://ab7d-81-185-173-5.ngrok.io/Login/oidcLoginSuccess&state=STATE&response_mode=form_post
-     * 
+     *
      * causes a POST but from the client, so let's return that to the client and make-pretend in the test
      * state: STATE
      * code: CODE
@@ -151,14 +151,14 @@ public class MockAppleOidcTestResource extends MockOidcTestResource<MockAppleOid
     /*
      * OIDC calls POST /auth/token
      * POST /auth/token
-     * 
+     *
      * grant_type=authorization_code
      * &code=CODE
      * &redirect_uri=https%3A%2F%2Fab7d-81-185-173-5.ngrok.io%2FLogin%2FoidcLoginSuccess
      * &client_id=CLIENT
      * &client_secret=GENERATED_JWT
-     * 
-     * 
+     *
+     *
      * {
      * "access_token":"TOKEN",
      * "token_type":"Bearer",
@@ -166,7 +166,7 @@ public class MockAppleOidcTestResource extends MockOidcTestResource<MockAppleOid
      * "refresh_token":"TOKEN2",
      * "id_token":"JWT"
      * }
-     * 
+     *
      * {
      * "iss": "https://appleid.apple.com",
      * "aud": "CLIENT",

--- a/oidc-tests/src/main/java/io/quarkiverse/renarde/oidc/test/MockFacebookOidcTestResource.java
+++ b/oidc-tests/src/main/java/io/quarkiverse/renarde/oidc/test/MockFacebookOidcTestResource.java
@@ -102,7 +102,7 @@ public class MockFacebookOidcTestResource extends MockOidcTestResource<MockFaceb
      * GET
      * https://facebook.com/dialog/oauth/?response_type=code&client_id=CLIENT&scope=openid+email+public_profile&redirect_uri=
      * http://localhost:8080/Login/facebookLoginSuccess&state=STATE
-     * 
+     *
      * returns a 302 to
      * GET http://localhost:8080/Login/facebookLoginSuccess?code=CODE&state=STATE
      */
@@ -135,7 +135,7 @@ public class MockFacebookOidcTestResource extends MockOidcTestResource<MockFaceb
      * grant_type=authorization_code
      * &code=CODE
      * &redirect_uri=http%3A%2F%2Flocalhost%3A8080%2FLogin%2FfacebookLoginSuccess
-     * 
+     *
      * returns:
      * {
      * "access_token":TOKEN,
@@ -143,7 +143,7 @@ public class MockFacebookOidcTestResource extends MockOidcTestResource<MockFaceb
      * "token_type":"bearer",
      * "expires_in":5172337
      * }
-     * 
+     *
      * {
      * "iss": "https://www.facebook.com",
      * "aud": "XXX",

--- a/oidc-tests/src/main/java/io/quarkiverse/renarde/oidc/test/MockGoogleOidcTestResource.java
+++ b/oidc-tests/src/main/java/io/quarkiverse/renarde/oidc/test/MockGoogleOidcTestResource.java
@@ -111,7 +111,7 @@ public class MockGoogleOidcTestResource extends MockOidcTestResource<MockGoogleO
      * First request:
      * GET https://accounts.google.com/o/oauth2/v2/auth?response_type=code&client_id=SECRET&scope=openid+openid+email+profile&
      * redirect_uri=http%3A%2F%2Flocalhost%3A8080%2FLogin%2FoidcLoginSuccess&state=STATE
-     * 
+     *
      * returns a 302 to
      * GET
      * http://localhost:8080/Login/oidcLoginSuccess?state=STATE&code=CODE&scope=email+profile+openid+https://www.googleapis.com/
@@ -148,7 +148,7 @@ public class MockGoogleOidcTestResource extends MockOidcTestResource<MockGoogleO
      * "token_type": "Bearer",
      * "id_token": "...JWT..."
      * }
-     * 
+     *
      * ID token:
      * {
      * "iss": "https://accounts.google.com",

--- a/oidc-tests/src/main/java/io/quarkiverse/renarde/oidc/test/MockMicrosoftOidcTestResource.java
+++ b/oidc-tests/src/main/java/io/quarkiverse/renarde/oidc/test/MockMicrosoftOidcTestResource.java
@@ -121,7 +121,7 @@ public class MockMicrosoftOidcTestResource extends MockOidcTestResource<MockMicr
      * GET
      * https://login.microsoftonline.com/common/oauth2/v2.0/authorize?response_type=code&client_id=SECRET&scope=openid+openid+
      * email+profile&redirect_uri=http://localhost:8080/Login/oidcLoginSuccess&state=STATE
-     * 
+     *
      * returns a 302 to
      * GET http://localhost:8080/Login/oidcLoginSuccess?code=CODE&state=STATE
      */
@@ -148,7 +148,7 @@ public class MockMicrosoftOidcTestResource extends MockOidcTestResource<MockMicr
      * OIDC calls POST /token
      * grant_type=authorization_code&code=CODE&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2FLogin%2FoidcLoginSuccess
      * returns:
-     * 
+     *
      * {
      * "token_type":"Bearer",
      * "scope":"openid email profile",
@@ -157,7 +157,7 @@ public class MockMicrosoftOidcTestResource extends MockOidcTestResource<MockMicr
      * "access_token":TOKEN,
      * "id_token":JWT
      * }
-     * 
+     *
      * ID token:
      * {
      * "ver": "2.0",

--- a/oidc-tests/src/main/java/io/quarkiverse/renarde/oidc/test/MockTwitterOidcTestResource.java
+++ b/oidc-tests/src/main/java/io/quarkiverse/renarde/oidc/test/MockTwitterOidcTestResource.java
@@ -70,12 +70,12 @@ public class MockTwitterOidcTestResource extends MockOidcTestResource<MockTwitte
     /*
      * OIDC calls POST https://api.twitter.com/2/oauth2/token
      * Authorization: Basic AUTH
-     * 
+     *
      * grant_type=authorization_code
      * code=CODE
      * redirect_uri=http://localhost:8080/_renarde/security/oidc-success
      * code_verifier=VERIFIER
-     * 
+     *
      * returns:
      * {
      * "token_type":"bearer",

--- a/oidc/src/main/java/io/quarkiverse/renarde/oidc/ControllerWithUser.java
+++ b/oidc/src/main/java/io/quarkiverse/renarde/oidc/ControllerWithUser.java
@@ -6,7 +6,7 @@ import io.quarkiverse.renarde.Controller;
 
 /**
  * A controller subtype with a current user.
- * 
+ *
  * @param <U> your implementation of {@link RenardeUser}
  */
 public abstract class ControllerWithUser<U extends RenardeUser> extends Controller {
@@ -16,7 +16,7 @@ public abstract class ControllerWithUser<U extends RenardeUser> extends Controll
     @SuppressWarnings("unchecked")
     /**
      * Obtains the currently logged in user, if any.
-     * 
+     *
      * @return the currently logged in user, or null.
      */
     protected U getUser() {

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.quarkiverse</groupId>
     <artifactId>quarkiverse-parent</artifactId>
-    <version>9</version>
+    <version>10</version>
   </parent>
   <groupId>io.quarkiverse.renarde</groupId>
   <artifactId>quarkus-renarde-parent</artifactId>


### PR DESCRIPTION
Looking at https://github.com/quarkiverse/quarkus-renarde/actions/runs/2607848730, specifically
````
2022-07-04T06:21:31.1513171Z [ERROR] Error executing Maven.
2022-07-04T06:21:31.1516833Z [ERROR] The specified user settings file does not exist: /home/runner/work/quarkus-renarde/quarkus-renarde/current-repo/integration-tests/target/quarkus-codestart-test/quarkus-renarde-352c7605-cbce-40a1-8161-7b173a814556/real-data/java/.github/quarkus-ecosystem-maven-settings.xml
````
propagating the absolute path to settings xml could help.
