### PR TITLE
Added support for enctype to form tag

### DIFF
--- a/runtime/src/main/resources/templates/tags/form.html
+++ b/runtime/src/main/resources/templates/tags/form.html
@@ -1,4 +1,4 @@
-<form action="{it}" method="{method ?: 'POST'}" {#if class??}class="{class}"{/if} {#if id??}id="{id}"{/if}>
+<form action="{it}" method="{method ?: 'POST'}" {#if class??}class="{class}"{/if} {#if id??}id="{id}"{/if} {#if enctype??}enctype="{enctype}"{/if}>
  {#authenticityToken/}
  {nested-content}
 </form>


### PR DESCRIPTION
It should be possible to supply an `enctype` to `{#form}` in order to handle POSTing multipart form data correctly. 

Example template:
```
{#form uri:MyTemplate.upload() enctype="multipart/form-data"}
    {#input id="file" name="file" type="file" /}
    <button type="submit" class="btn btn-primary">Upload</button>
{/form}
```

Example controller:
```java
@POST
@Consumes(MediaType.MULTIPART_FORM_DATA)
public void upload(@RestForm("file") FileUpload file) {
   // do stuff to uploaded file ...
}
```
