### PR TITLE
Fix for validation errors not being immediately available in the next rendered template

### DIFF
--- a/integration-tests/src/main/java/rest/Application.java
+++ b/integration-tests/src/main/java/rest/Application.java
@@ -32,6 +32,7 @@ import io.quarkiverse.renarde.Controller;
 import io.quarkiverse.renarde.router.Router;
 import io.quarkus.qute.CheckedTemplate;
 import io.quarkus.qute.TemplateInstance;
+import io.smallrye.common.annotation.Blocking;
 
 public class Application extends Controller {
 
@@ -40,6 +41,8 @@ public class Application extends Controller {
         public static native TemplateInstance index();
 
         public static native TemplateInstance routingTags();
+
+        public static native TemplateInstance validationError(String email);
     }
 
     @POST
@@ -60,6 +63,18 @@ public class Application extends Controller {
 
     public TemplateInstance routingTags() {
         return Templates.routingTags();
+    }
+
+    @Blocking
+    @POST
+    public TemplateInstance validationError(@RestForm String email) {
+        validation.addError("email", "Error");
+
+        if (validationFailed()) {
+            return Templates.validationError(email);
+        }
+
+        return Templates.index();
     }
 
     @Path("/absolute")

--- a/integration-tests/src/main/resources/templates/Application/validationError.html
+++ b/integration-tests/src/main/resources/templates/Application/validationError.html
@@ -1,0 +1,1 @@
+{#ifError "email"}{#error "email" /}{/ifError}

--- a/integration-tests/src/test/java/io/quarkiverse/renarde/it/RenardeResourceTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/renarde/it/RenardeResourceTest.java
@@ -105,4 +105,15 @@ public class RenardeResourceTest {
                 .statusCode(200)
                 .body(is("param: myParam, file: file contents, fileUpload: fileUpload.txt"));
     }
+
+    @Test
+    public void testValidationError() {
+        given()
+                .when()
+                .multiPart("email", "foo@bar.com")
+                .post("/Application/validationError")
+                .then()
+                .statusCode(200)
+                .body(is("Error\n\n")); // one newline for {#ifError}, one for {#error}
+    }
 }

--- a/runtime/src/main/java/io/quarkiverse/renarde/util/Flash.java
+++ b/runtime/src/main/java/io/quarkiverse/renarde/util/Flash.java
@@ -137,7 +137,7 @@ public class Flash {
 
     // FIXME: this is just to get around not being able to prefix error. in Qute
     public <T> T getError(String key) {
-        return (T) values.get("error." + key);
+        return (T) futureValues.get("error." + key);
     }
 
     public Map<String, Object> values() {


### PR DESCRIPTION
* use `futureValues` instead of `values` in `Flash.getError(String)`
* added integration test to simulate the situation

Signed-off-by:Nathan Erwin <nathan.d.erwin@gmail.com>