### PR TITLE
Secure cookies if served over secure connection (HTTPS).

### DIFF
--- a/integration-tests/src/test/java/io/quarkiverse/renarde/it/RenardeResourceTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/renarde/it/RenardeResourceTest.java
@@ -152,7 +152,8 @@ public class RenardeResourceTest {
                 .cookie(Flash.FLASH_COOKIE_NAME,
                         RestAssuredMatchers.detailedCookie()
                                 .sameSite("Lax")
-                                .httpOnly(true))
+                                .httpOnly(true)
+                                .secured("https".equals(baseURI.getProtocol())))
                 .extract().header("Location");
         given()
                 .redirects().follow(false)

--- a/runtime/src/main/java/io/quarkiverse/renarde/util/AuthenticationFailedExceptionMapper.java
+++ b/runtime/src/main/java/io/quarkiverse/renarde/util/AuthenticationFailedExceptionMapper.java
@@ -87,7 +87,7 @@ public class AuthenticationFailedExceptionMapper {
                 Map<String, Object> map = new HashMap<>();
                 // FIXME: format?
                 map.put("message", message);
-                Flash.setFlashCookie(routingContext.response(), map);
+                Flash.setFlashCookie(routingContext.request(), routingContext.response(), map);
                 // FIXME: URI, perhaps redirect to login page?
                 // Note that this calls end()
                 routingContext.response().setStatusCode(303);

--- a/runtime/src/main/java/io/quarkiverse/renarde/util/CRSF.java
+++ b/runtime/src/main/java/io/quarkiverse/renarde/util/CRSF.java
@@ -42,7 +42,9 @@ public class CRSF {
          */
         if (!request.response().headWritten() && crsfToken != null)
             request.response().addCookie(
-                    Cookie.cookie(CRSF_COOKIE_NAME, crsfToken).setPath("/"));
+                    Cookie.cookie(CRSF_COOKIE_NAME, crsfToken)
+                            .setPath("/")
+                            .setSecure(request.isSSL()));
     }
 
     public void readCRSFCookie() {

--- a/runtime/src/main/java/io/quarkiverse/renarde/util/Flash.java
+++ b/runtime/src/main/java/io/quarkiverse/renarde/util/Flash.java
@@ -41,10 +41,10 @@ public class Flash {
     public final static String FLASH_COOKIE_NAME = "_renarde_flash";
 
     public void setFlashCookie() {
-        setFlashCookie(request.response(), futureValues);
+        setFlashCookie(request, request.response(), futureValues);
     }
 
-    public static void setFlashCookie(HttpServerResponse response, Map<String, Object> values) {
+    public static void setFlashCookie(HttpServerRequest request, HttpServerResponse response, Map<String, Object> values) {
         // FIXME: expiry, others?
         // in some cases with exception mappers, it appears the filters get invoked twice
         if (!response.headWritten())
@@ -52,7 +52,8 @@ public class Flash {
                     Cookie.cookie(FLASH_COOKIE_NAME, encodeCookieValue(values))
                             .setPath("/")
                             .setHttpOnly(true)
-                            .setSameSite(CookieSameSite.LAX));
+                            .setSameSite(CookieSameSite.LAX)
+                            .setSecure(request.isSSL()));
     }
 
     public static String encodeCookieValue(Map<String, Object> values) {

--- a/runtime/src/main/java/io/quarkiverse/renarde/util/I18N.java
+++ b/runtime/src/main/java/io/quarkiverse/renarde/util/I18N.java
@@ -89,7 +89,8 @@ public class I18N {
             response.addCookie(
                     io.vertx.core.http.Cookie.cookie(LANGUAGE_COOKIE_NAME, language)
                             .setPath("/")
-                            .setSameSite(CookieSameSite.LAX));
+                            .setSameSite(CookieSameSite.LAX)
+                            .setSecure(request.isSSL()));
         }
     }
 


### PR DESCRIPTION
I've added secure cookie attribute for Renarde cookies (for CRSF, Flash, I18N). All existing tests have passed. I built my project with this version of Renarde and everything works in dev mode and in production.

![secure](https://github.com/quarkiverse/quarkus-renarde/assets/3283510/41dc9c08-a30d-48e3-9edd-0a6961f1f6a6)
