### PR TITLE
CSRF doc for htmx

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -1139,6 +1139,14 @@ public class Application extends HxController {
 <4> Only Hx requests are allowed, else it will fail with a BAD_REQUEST error
 <5> Flag the response with an https://htmx.org/reference/#response_headers[htmx response header]
 
+For CSRF Security, you need a form parameter with the CSRF Token. By adding this 👇 when doing a hx-post/put/delete, The Hx requests will be sent with the CSRF parameter:
+[source,html]
+----
+<div hx-post"/hello" hx-vals='{"{inject:csrf.parameterName}": "{inject:csrf.token}"}'>
+---
+
+NOTE: There is a ongoing issue to allow using a header instead of a form parameter (https://github.com/quarkusio/quarkus/issues/34513), this way it will be possible to have a `hx-headers` on the <body> to make all hx requests secured with CSRF.
+
 Some example projects with Quarkus Renarde and htmx:
 - https://github.com/ia3andy/renotes[a demo note-taking web app]
 - https://github.com/ia3andy/quarkus-blast[a board game]

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -1143,7 +1143,7 @@ For CSRF Security, you need a form parameter with the CSRF Token. By adding this
 [source,html]
 ----
 <div hx-post"/hello" hx-vals='{"{inject:csrf.parameterName}": "{inject:csrf.token}"}'>
----
+----
 
 NOTE: There is a ongoing issue to allow using a header instead of a form parameter (https://github.com/quarkusio/quarkus/issues/34513), this way it will be possible to have a `hx-headers` on the <body> to make all hx requests secured with CSRF.
 


### PR DESCRIPTION
This is a temporary solution:
There is a ongoing issue to allow using a header instead of a form parameter (https://github.com/quarkusio/quarkus/issues/34513), this way it will be possible to have a `hx-headers` on the <body> to make all hx requests secured with CSRF.