### PR TITLE
add X-Fragment and X-Template http headers

### DIFF
--- a/deployment/src/test/java/io/quarkiverse/renarde/test/TemplateHttpHeadersTest.java
+++ b/deployment/src/test/java/io/quarkiverse/renarde/test/TemplateHttpHeadersTest.java
@@ -1,0 +1,68 @@
+package io.quarkiverse.renarde.test;
+
+import io.quarkiverse.renarde.Controller;
+import io.quarkus.qute.CheckedTemplate;
+import io.quarkus.qute.TemplateInstance;
+import io.quarkus.test.QuarkusUnitTest;
+import jakarta.ws.rs.Path;
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static io.restassured.RestAssured.when;
+
+public class TemplateHttpHeadersTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(MyController.class)
+                            .addAsResource(new StringAsset("""
+                                    template content
+                                    {#fragment id="fragment" rendered=false}
+                                    fragment template
+                                    {/fragment}
+                                    """), "templates/MyController/template.html")
+            );
+
+    @Test
+    public void testTemplateHeaders() {
+
+        when()
+                .get("/template").then()
+                .header("X-Fragment", "false")
+                .header("X-Template", "MyController/template.html")
+                .statusCode(200)
+                .body(Matchers.is("template content\n"));
+
+        when()
+                .get("/fragment").then()
+                .header("X-Fragment", "true")
+                .header("X-Template", "MyController/template.html.fragment")
+                .statusCode(200)
+                .body(Matchers.is("fragment template\n"));
+    }
+
+    public static class MyController extends Controller {
+
+        @CheckedTemplate
+        public static class Templates {
+            public static native TemplateInstance template();
+            public static native TemplateInstance template$fragment();
+        }
+
+        @Path("/template")
+        public TemplateInstance template() {
+            return Templates.template();
+        }
+
+        @Path("/fragment")
+        public TemplateInstance fragment() {
+            return Templates.template$fragment();
+        }
+
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/renarde/test/TemplateHttpHeadersTest.java
+++ b/deployment/src/test/java/io/quarkiverse/renarde/test/TemplateHttpHeadersTest.java
@@ -1,10 +1,9 @@
 package io.quarkiverse.renarde.test;
 
-import io.quarkiverse.renarde.Controller;
-import io.quarkus.qute.CheckedTemplate;
-import io.quarkus.qute.TemplateInstance;
-import io.quarkus.test.QuarkusUnitTest;
+import static io.restassured.RestAssured.when;
+
 import jakarta.ws.rs.Path;
+
 import org.hamcrest.Matchers;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -12,21 +11,23 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import static io.restassured.RestAssured.when;
+import io.quarkiverse.renarde.Controller;
+import io.quarkus.qute.CheckedTemplate;
+import io.quarkus.qute.TemplateInstance;
+import io.quarkus.test.QuarkusUnitTest;
 
 public class TemplateHttpHeadersTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = new QuarkusUnitTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                            .addClasses(MyController.class)
-                            .addAsResource(new StringAsset("""
-                                    template content
-                                    {#fragment id="fragment" rendered=false}
-                                    fragment template
-                                    {/fragment}
-                                    """), "templates/MyController/template.html")
-            );
+                    .addClasses(MyController.class)
+                    .addAsResource(new StringAsset("""
+                            template content
+                            {#fragment id="fragment" rendered=false}
+                            fragment template
+                            {/fragment}
+                            """), "templates/MyController/template.html"));
 
     @Test
     public void testTemplateHeaders() {
@@ -51,6 +52,7 @@ public class TemplateHttpHeadersTest {
         @CheckedTemplate
         public static class Templates {
             public static native TemplateInstance template();
+
             public static native TemplateInstance template$fragment();
         }
 

--- a/runtime/src/main/java/io/quarkiverse/renarde/util/QuteResolvers.java
+++ b/runtime/src/main/java/io/quarkiverse/renarde/util/QuteResolvers.java
@@ -1,6 +1,5 @@
 package io.quarkiverse.renarde.util;
 
-import java.lang.reflect.Field;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -139,19 +138,11 @@ public class QuteResolvers {
                 RoutingContext routingContext = Arc.container().instance(RoutingContext.class).get();
                 MultiMap headers = routingContext.response().headers();
                 Template template = templateInstance.getTemplate();
-                boolean isFragment = template.getClass().getName().equals("io.quarkus.qute.TemplateImpl$FragmentImpl");
+                boolean isFragment = template.isFragment();
                 String parentTemplateId = "";
                 if (isFragment) {
-                    try {
-                        Field rootField = template.getClass().getEnclosingClass().getDeclaredField("root");
-                        rootField.setAccessible(true);
-                        var sectionNode = rootField.get(template);
-                        Field originField = sectionNode.getClass().getDeclaredField("origin");
-                        originField.setAccessible(true);
-                        TemplateNode.Origin origin = (TemplateNode.Origin) originField.get(sectionNode);
-                        parentTemplateId = origin.getTemplateId() + ".";
-                    } catch (IllegalAccessException | NoSuchFieldException ignored) {
-                    }
+                    var fragment = (Template.Fragment) template;
+                    parentTemplateId = fragment.getOriginalTemplate().getId() + ".";
                 }
 
                 // if we send an email before returning the template the headers get added twice

--- a/runtime/src/main/java/io/quarkiverse/renarde/util/QuteResolvers.java
+++ b/runtime/src/main/java/io/quarkiverse/renarde/util/QuteResolvers.java
@@ -154,8 +154,9 @@ public class QuteResolvers {
                     }
                 }
 
-                headers.add("X-Template", parentTemplateId + template.getId());
-                headers.add("X-Fragment", Boolean.toString(isFragment));
+                // if we send an email before returning the template the headers get added twice
+                headers.remove("X-Template").add("X-Template", parentTemplateId + template.getId());
+                headers.remove("X-Fragment").add("X-Fragment", Boolean.toString(isFragment));
             });
         }
 

--- a/runtime/src/main/java/io/quarkiverse/renarde/util/QuteResolvers.java
+++ b/runtime/src/main/java/io/quarkiverse/renarde/util/QuteResolvers.java
@@ -133,6 +133,9 @@ public class QuteResolvers {
 
         if (ProfileManager.getLaunchMode().isDevOrTest()) {
             engineBuilder.addTemplateInstanceInitializer(templateInstance -> {
+                if (!Arc.container().requestContext().isActive()) {
+                    return;
+                }
                 RoutingContext routingContext = Arc.container().instance(RoutingContext.class).get();
                 MultiMap headers = routingContext.response().headers();
                 Template template = templateInstance.getTemplate();


### PR DESCRIPTION
I'm currently in the process of writing Renarde tests and would like to ensure that the correct templates are being returned. While I can certainly test the template content itself, I believe there is room for improvement.

One suggestion is to include the following http headers in dev/test mode:

X-Template: "template_name" | "template_name.fragment_name"
X-Fragment: "true|false"