### PR TITLE
Use new web-dependency-locator

### DIFF
--- a/docs/modules/ROOT/pages/concepts.adoc
+++ b/docs/modules/ROOT/pages/concepts.adoc
@@ -525,36 +525,5 @@ This system uses this line separator: {lineSeparator}
 
 === External CSS, JavaScript libraries
 
-You can use webjars to provide third-party JavaScript or CSS. For example, here is how you can import Bootstrap
-and Bootstrap-icons in your `pom.xml`:
+if you want to insert scripts, styles, and libraries in your web pages, Quarkus provides different option, please refer to the https://quarkus.io/guides/web#serving-scripts-styles-and-web-libraries[Quarkus for the Web guide]
 
-[source,xml]
-----
-<dependency>
-  <groupId>org.webjars</groupId>
-  <artifactId>bootstrap</artifactId>
-  <version>5.1.3</version>
-</dependency>
-<dependency>
-  <groupId>org.webjars.npm</groupId>
-  <artifactId>bootstrap-icons</artifactId>
-  <version>1.7.0</version>
-</dependency>
-<dependency>
-  <groupId>io.quarkus</groupId>
-  <artifactId>quarkus-webjars-locator</artifactId>
-</dependency>
-----
-
-After that, you can include them in your Qute templates with:
-
-[source,html]
-----
-<head>
-    <link rel="stylesheet" media="screen" href="/webjars/bootstrap/css/bootstrap.min.css">
-    <link rel="stylesheet" media="screen" href="/webjars/bootstrap-icons/font/bootstrap-icons.css">
-    <script src="/webjars/bootstrap/js/bootstrap.min.js" type="text/javascript" charset="UTF-8"></script>
-</head>
-----
-
-Look at https://mvnrepository.com/artifact/org.webjars for the list of available options.

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -78,18 +78,18 @@
     	<scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.webjars</groupId>
+      <groupId>org.mvnpm</groupId>
       <artifactId>bootstrap</artifactId>
       <version>5.2.3</version>
     </dependency>
     <dependency>
-      <groupId>org.webjars.npm</groupId>
+      <groupId>org.mvnpm</groupId>
       <artifactId>bootstrap-icons</artifactId>
-      <version>1.10.3</version>
+      <version>1.11.3</version>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-webjars-locator</artifactId>
+      <artifactId>quarkus-web-dependency-locator</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/integration-tests/src/main/resources/templates/HtmxApp/index.html
+++ b/integration-tests/src/main/resources/templates/HtmxApp/index.html
@@ -7,7 +7,7 @@
   <title>Htmx Powered</title>
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
   <script src="/htmx.js"></script>
-  <link rel="stylesheet" media="screen" href="/webjars/bootstrap/css/bootstrap.min.css">
+  <link rel="stylesheet" media="screen" href="/_static/bootstrap/css/bootstrap.min.css">
   <style>
     input:read-only {
       background-color: #e9ecef;

--- a/integration-tests/src/main/resources/templates/main.html
+++ b/integration-tests/src/main/resources/templates/main.html
@@ -4,12 +4,12 @@
         <title>{#insert title /}</title>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <link rel="stylesheet" media="screen" href="/webjars/bootstrap/css/bootstrap.min.css">
-        <link rel="stylesheet" media="screen" href="/webjars/bootstrap-icons/font/bootstrap-icons.css">
+        <link rel="stylesheet" media="screen" href="/_static/bootstrap/css/bootstrap.min.css">
+        <link rel="stylesheet" media="screen" href="/_static/bootstrap-icons/font/bootstrap-icons.css">
         <link rel="stylesheet" media="screen" href="/stylesheets/main.css">
         {#insert moreStyles /}
-        <link rel="shortcut icon" type="image/png" href="/webjars/bootstrap-icons/icons/check2-square.svg">
-        <script src="/webjars/bootstrap/js/bootstrap.min.js" type="text/javascript" charset="UTF-8"></script>
+        <link rel="shortcut icon" type="image/png" href="/_static/bootstrap-icons/icons/check2-square.svg">
+        <script src="/_static/bootstrap/js/bootstrap.min.js" type="text/javascript" charset="UTF-8"></script>
         <script src="/javascripts/main.js" type="text/javascript" charset="UTF-8"></script>
         {#insert moreScripts /}
     </head>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <maven.compiler.release>17</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus.version>3.9.4</quarkus.version>
+    <quarkus.version>3.10.0</quarkus.version>
     <openhtmltopdf.version>1.0.10</openhtmltopdf.version>
     <zxing.version>3.5.1</zxing.version>
   </properties>


### PR DESCRIPTION
This PR also:
- switch to mvnpm as default in integration test.
- update doc to refer to the Quarkus for the Web doc for assets

It needs to wait for a new release of Quarkus to work (as 3.10 doesn't have the change)
