### PR TITLE
Docs improvements

### DIFF
--- a/docs/modules/ROOT/pages/advanced.adoc
+++ b/docs/modules/ROOT/pages/advanced.adoc
@@ -41,11 +41,13 @@ Creating forms in Renarde is easy: let's see an example of how to do it in Qute:
 {/form}
 ----
 
-Here we're defining a form whose action will go to `Register.complete(newUser.confirmationCode)` and
-which contains several form elements, which are just tags to make composition easier. For example `formElement` is
-a custom Qute tag for Bootstrap which defines layout for the form element and displays any associated error:
+Here we're defining a form whose action will go to `Login.complete(newUser.confirmationCode)` and
+which contains several form elements, which are just tags to make composition easier.
+
+For example `formElement` is a custom Qute tag (see xref:concepts.adoc#_user_tags[User tags]) for Bootstrap which defines layout for the form element and displays any associated error:
 
 [source,html]
+.content of the `templates/tags/formElement.html`
 ----
 <div class="mb-3">
     <label class="form-label" for="{name}">{label}</label>
@@ -59,6 +61,7 @@ a custom Qute tag for Bootstrap which defines layout for the form element and di
 The `input` user tag is also designed for Bootstrap as an abstraction:
 
 [source,html]
+.content of the `templates/tags/input.html`
 ----
 <input name="{name}"
  type="{type ?: 'text'}"
@@ -72,7 +75,7 @@ As you can see, we have default values for certain attributes, a special error c
 error, and we default the value to the one preserved in the flash scope, which is filled whenever validation
 fails, so that the user can see the validation error without losing their form values.
 
-As for the `form` Renarde tag, it is also fairly simple, and only includes an authenticity token for CSRF protection.
+As for the `form` xref:concepts.adoc#_renarde_tags[Renarde tag], it is also fairly simple, and only includes an authenticity token for CSRF protection.
 
 [source,html]
 ----

--- a/docs/modules/ROOT/pages/advanced.adoc
+++ b/docs/modules/ROOT/pages/advanced.adoc
@@ -347,8 +347,8 @@ Naturally, you can also pass any required parameters.
 </dependency>
 ----
 
-Often you will need your actions to send email notifications.You can use Qute for this too, by declaring your
-emails in an `Emails` class:
+Often you will need your actions to send email notifications.
+You can use Qute for this too, by declaring your emails in an `Emails` class:
 
 [source,java]
 ----
@@ -626,6 +626,7 @@ Alternatively, you can use `hx-headers` on the <body> to make all hx requests se
 ----
 
 Some example projects with Quarkus Renarde and htmx:
+
 - https://github.com/ia3andy/renotes[a demo note-taking web app]
 - https://github.com/ia3andy/quarkus-blast[a board game]
 

--- a/docs/modules/ROOT/pages/concepts.adoc
+++ b/docs/modules/ROOT/pages/concepts.adoc
@@ -525,24 +525,26 @@ This system uses this line separator: {lineSeparator}
 
 === External CSS, JavaScript libraries
 
-You can use webjars to provide third-party JavaScript or CSS. For example, here is how you can import Bootstrap
-and Bootstrap-icons in your `pom.xml`:
+You can use jars created by https://mvnpm.org/[mvnpm.org] to provide third-party JavaScript or CSS hosted on the https://www.npmjs.com/[NPM Registry].
+For example, here is how you can import Bootstrap and Bootstrap-icons in your `pom.xml`:
 
 [source,xml]
 ----
 <dependency>
-  <groupId>org.webjars</groupId>
+  <groupId>org.mvnpm</groupId>
   <artifactId>bootstrap</artifactId>
-  <version>5.1.3</version>
+  <version>5.3.3</version>
+  <scope>provided</scope>
 </dependency>
 <dependency>
-  <groupId>org.webjars.npm</groupId>
+  <groupId>org.mvnpm</groupId>
   <artifactId>bootstrap-icons</artifactId>
-  <version>1.7.0</version>
+  <version>1.11.3</version>
+  <scope>provided</scope>
 </dependency>
 <dependency>
   <groupId>io.quarkus</groupId>
-  <artifactId>quarkus-webjars-locator</artifactId>
+  <artifactId>quarkus-web-dependency-locator</artifactId>
 </dependency>
 ----
 
@@ -551,10 +553,10 @@ After that, you can include them in your Qute templates with:
 [source,html]
 ----
 <head>
-    <link rel="stylesheet" media="screen" href="/webjars/bootstrap/css/bootstrap.min.css">
-    <link rel="stylesheet" media="screen" href="/webjars/bootstrap-icons/font/bootstrap-icons.css">
-    <script src="/webjars/bootstrap/js/bootstrap.min.js" type="text/javascript" charset="UTF-8"></script>
+    <link rel="stylesheet" media="screen" href="/_static/bootstrap/dist/css/bootstrap.css">
+    <link rel="stylesheet" media="screen" href="/_static/bootstrap-icons/font/bootstrap-icons.css">
+    <script src="/_static/bootstrap/js/bootstrap.min.js" type="text/javascript" charset="UTF-8"></script>
 </head>
 ----
 
-Look at https://mvnrepository.com/artifact/org.webjars for the list of available options.
+Check the https://quarkus.io/guides/web-dependency-locator[web-dependency-locator] extension guide for more information.

--- a/runtime/src/main/codestarts/quarkus/renarde-codestart/codestart.yml
+++ b/runtime/src/main/codestarts/quarkus/renarde-codestart/codestart.yml
@@ -4,6 +4,6 @@ type: code
 tags: extension-codestart
 metadata:
   title: Renarde
-  description: This is a small Renarde webapp
+  description: This is a small Renarde webapp. Once the quarkus app is started visit http://localhost:8080/renarde
   path: /renarde
   related-guide-section: https://quarkiverse.github.io/quarkiverse-docs/quarkus-renarde/dev/index.html


### PR DESCRIPTION
*  Fix whitespaces in `advanced.adoc` to fix the list display and the split between sentenses
*  Improve the form section in `advanced.adoc` to make it more clear what is built-in and what is a specific file that need to be created
* In `concepts.adoc` Update to `web-dependency-locator` instead of `quarkus-webjars-locator` that no longer exists and use mvnpm instead of webjars.
* Improve the readme generated by the starter code to indicate where to click when the example app is started (similar to https://github.com/quarkiverse/quarkus-qute-web/pull/111 and https://github.com/quarkiverse/quarkus-web-bundler/pull/264)
