### PR TITLE
Renard validator(MyValidationInterceptor) should not apply on rest enpoint that not extends renarde.Controller

### DIFF
--- a/integration-tests/src/main/java/rest/ValidationController.java
+++ b/integration-tests/src/main/java/rest/ValidationController.java
@@ -1,0 +1,30 @@
+package rest;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.jboss.resteasy.reactive.RestQuery;
+
+import io.quarkiverse.renarde.Controller;
+
+public class ValidationController {
+    @Path("/ValidationController")
+    public static class RenardController extends Controller {
+        @GET
+        @Path("/RenardController")
+        public void renardValidate(@Valid @NotNull @RestQuery String input) {
+
+        }
+    }
+
+    @Path("/ValidationController")
+    public static class RestController {
+        @GET
+        @Path("/RestController")
+        public void restValidate(@Valid @NotNull @RestQuery String input) {
+
+        }
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/renarde/it/ValidationTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/renarde/it/ValidationTest.java
@@ -1,0 +1,26 @@
+package io.quarkiverse.renarde.it;
+
+import static io.restassured.RestAssured.given;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class ValidationTest {
+    @Test
+    public void validateOnRenardeEndpointShouldResponse20x() {
+        given()
+                .when().get("/ValidationController/RenardController")
+                .then()
+                .statusCode(204);
+    }
+
+    @Test
+    public void validateOnRestEndpointShouldResponse400() {
+        given()
+                .when().get("/ValidationController/RestController")
+                .then()
+                .statusCode(400);
+    }
+}

--- a/runtime/src/main/java/io/quarkiverse/renarde/util/MyValidationInterceptor.java
+++ b/runtime/src/main/java/io/quarkiverse/renarde/util/MyValidationInterceptor.java
@@ -2,6 +2,7 @@ package io.quarkiverse.renarde.util;
 
 import java.util.Set;
 
+import io.quarkiverse.renarde.Controller;
 import jakarta.annotation.Priority;
 import jakarta.inject.Inject;
 import jakarta.interceptor.AroundConstruct;
@@ -35,8 +36,12 @@ public class MyValidationInterceptor extends AbstractMethodValidationInterceptor
                 ctx.getMethod(), ctx.getParameters());
 
         if (!violations.isEmpty()) {
-            // just collect them and go on
-            validation.addErrors(violations);
+            if(ctx.getTarget() instanceof Controller){
+                // just collect them and go on
+                validation.addErrors(violations);
+            }else{
+                throw new ResteasyReactiveViolationException(violations);
+            }
         }
 
         Object result = ctx.proceed();

--- a/runtime/src/main/java/io/quarkiverse/renarde/util/MyValidationInterceptor.java
+++ b/runtime/src/main/java/io/quarkiverse/renarde/util/MyValidationInterceptor.java
@@ -2,7 +2,6 @@ package io.quarkiverse.renarde.util;
 
 import java.util.Set;
 
-import io.quarkiverse.renarde.Controller;
 import jakarta.annotation.Priority;
 import jakarta.inject.Inject;
 import jakarta.interceptor.AroundConstruct;
@@ -13,6 +12,7 @@ import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validator;
 import jakarta.validation.executable.ExecutableValidator;
 
+import io.quarkiverse.renarde.Controller;
 import io.quarkus.hibernate.validator.runtime.interceptor.AbstractMethodValidationInterceptor;
 import io.quarkus.hibernate.validator.runtime.jaxrs.JaxrsEndPointValidated;
 import io.quarkus.hibernate.validator.runtime.jaxrs.ResteasyReactiveViolationException;
@@ -36,10 +36,10 @@ public class MyValidationInterceptor extends AbstractMethodValidationInterceptor
                 ctx.getMethod(), ctx.getParameters());
 
         if (!violations.isEmpty()) {
-            if(ctx.getTarget() instanceof Controller){
+            if (ctx.getTarget() instanceof Controller) {
                 // just collect them and go on
                 validation.addErrors(violations);
-            }else{
+            } else {
                 throw new ResteasyReactiveViolationException(violations);
             }
         }


### PR DESCRIPTION
I have 2 controller 
1. json rest 
2. htmx (renard controller)
when I apply @Valid on 1. I observe that MyValidationInterceptor add ConstrainViolation to validation.error event if my controller does not extends renard Controller. So I can't report error back to user like normal rest . and endpoint method get called even if validate fail (it is OK for htmx,html response)
