### PR TITLE
Use OIDC @ConfigMapping methods after config class migration when you migrate to Quarkus 3.17

### DIFF
--- a/oidc/src/main/java/io/quarkiverse/renarde/oidc/impl/RenardeOidcTenantProvider.java
+++ b/oidc/src/main/java/io/quarkiverse/renarde/oidc/impl/RenardeOidcTenantProvider.java
@@ -25,6 +25,6 @@ public class RenardeOidcTenantProvider implements RenardeTenantProvider {
 
     @Override
     public Set<String> getTenants() {
-        return oidcConfig.namedTenants.keySet();
+        return oidcConfig.namedTenants().keySet();
     }
 }

--- a/oidc/src/main/java/io/quarkiverse/renarde/oidc/impl/RenardeTenantResolver.java
+++ b/oidc/src/main/java/io/quarkiverse/renarde/oidc/impl/RenardeTenantResolver.java
@@ -7,7 +7,7 @@ import jakarta.inject.Inject;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
-import io.quarkus.oidc.OidcTenantConfig;
+import io.quarkus.oidc.runtime.OidcTenantConfig;
 import io.quarkus.oidc.TenantResolver;
 import io.quarkus.oidc.runtime.OidcConfig;
 import io.quarkus.oidc.runtime.OidcUtils;
@@ -29,8 +29,8 @@ public class RenardeTenantResolver implements TenantResolver {
         if (knownTenant != null)
             return knownTenant;
         // Named tenants
-        for (Entry<String, OidcTenantConfig> tenantEntry : oidcConfig.namedTenants.entrySet()) {
-            if (!tenantEntry.getValue().tenantEnabled)
+        for (Entry<String, OidcTenantConfig> tenantEntry : oidcConfig.namedTenants().entrySet()) {
+            if (!tenantEntry.getValue().tenantEnabled())
                 continue;
             String tenant = tenantEntry.getKey();
             // First case: login


### PR DESCRIPTION
I am opening this PR to give you heads-up that OIDC config classes have been migrated to `@ConfigMapping` interfaces, see https://github.com/quarkusio/quarkus/pull/44140. I have mentioned that right now, Quarkus Renarde is on 3.15 and there are other breaking changes, so I don't expect this PR to ever get in. Just close it when you read it. Thanks