### PR TITLE
Fix 284 - Removing redirection cookie after logout

### DIFF
--- a/deployment/src/test/java/io/quarkiverse/renarde/test/JWTTest.java
+++ b/deployment/src/test/java/io/quarkiverse/renarde/test/JWTTest.java
@@ -126,7 +126,8 @@ public class JWTTest {
                 .getValues("Set-Cookie")
                 .stream().filter(c -> c.startsWith("quarkus-redirect-location=")).findFirst().get();
 
-        Assertions.assertEquals("quarkus-redirect-location=\"" + uri + "\";Version=1;Path=/", quarkusRedirectCookie);
+        Assertions.assertEquals("quarkus-redirect-location=;Version=1;Path=/;Max-Age=0", quarkusRedirectCookie);
+        //Assertions.assertEquals("quarkus-redirect-location=\"" + uri + "\";Version=1;Path=/", quarkusRedirectCookie);
 
         String flash = response.cookie(Flash.FLASH_COOKIE_NAME);
         Map<String, Object> data = Flash.decodeCookieValue(flash);

--- a/deployment/src/test/java/io/quarkiverse/renarde/test/JWTTest.java
+++ b/deployment/src/test/java/io/quarkiverse/renarde/test/JWTTest.java
@@ -121,13 +121,12 @@ public class JWTTest {
 
         Assertions.assertEquals("QuarkusUser=;Version=1;Path=/;Max-Age=0", quarkusUserCookie);
 
-        // Make sure we saved the original URI
+        // The redirect cookie should now be invalidated
         String quarkusRedirectCookie = response.headers()
                 .getValues("Set-Cookie")
                 .stream().filter(c -> c.startsWith("quarkus-redirect-location=")).findFirst().get();
 
         Assertions.assertEquals("quarkus-redirect-location=;Version=1;Path=/;Max-Age=0", quarkusRedirectCookie);
-        //Assertions.assertEquals("quarkus-redirect-location=\"" + uri + "\";Version=1;Path=/", quarkusRedirectCookie);
 
         String flash = response.cookie(Flash.FLASH_COOKIE_NAME);
         Map<String, Object> data = Flash.decodeCookieValue(flash);

--- a/security/src/main/java/io/quarkiverse/renarde/security/RenardeSecurity.java
+++ b/security/src/main/java/io/quarkiverse/renarde/security/RenardeSecurity.java
@@ -161,8 +161,12 @@ public class RenardeSecurity {
         for (String tenant : tenants) {
             cookies.add(invalidateCookie(oidcCookie + "_" + tenant));
         }
+
         // Manual
         cookies.add(invalidateCookie(jwtCookie));
+
+        // Remove the redirect cookie (if it exists)
+        cookies.add(invalidateCookie(renardeConfig.auth().redirect().cookie()));
 
         return cookies.toArray(new NewCookie[0]);
     }

--- a/security/src/main/java/io/quarkiverse/renarde/security/RenardeSecurity.java
+++ b/security/src/main/java/io/quarkiverse/renarde/security/RenardeSecurity.java
@@ -165,8 +165,10 @@ public class RenardeSecurity {
         // Manual
         cookies.add(invalidateCookie(jwtCookie));
 
-        // Remove the redirect cookie (if it exists)
-        cookies.add(invalidateCookie(renardeConfig.auth().redirect().cookie()));
+        // Remove the redirect cookie (if it exists and we are using cookie redirection)
+        if (renardeConfig.auth().redirect().type() == RenardeConfig.RenardeAuthConfig.Redirect.Type.cookie) {
+            cookies.add(invalidateCookie(renardeConfig.auth().redirect().cookie()));
+        }
 
         return cookies.toArray(new NewCookie[0]);
     }


### PR DESCRIPTION
Fixes: https://github.com/quarkiverse/quarkus-renarde/issues/284

The `quarkus-redirect-location` cookie is now deleted when the `makeLogoutResponse` method is called.

The JWTTest was also updated to look for the changed `quarkus-redirect-location` cookie during the tests.
