### PR TITLE
avoid using QuarkusUser principal when an active OIDC session exists

### DIFF
--- a/oidc/src/main/java/io/quarkiverse/renarde/oidc/impl/RenardeOidcController.java
+++ b/oidc/src/main/java/io/quarkiverse/renarde/oidc/impl/RenardeOidcController.java
@@ -30,10 +30,12 @@ public class RenardeOidcController extends Controller {
     public void loginUsingOidc(@RestPath String provider) {
         // this can be called if we're authenticated on OIDC but the user didn't go through
         // with completion
-        JWTCallerPrincipal principal = (JWTCallerPrincipal) identity.getPrincipal();
+        JsonWebToken principal = (JWTCallerPrincipal) identity.getPrincipal();
         String tenantId = oidcSession.getTenantId();
         if (tenantId == null) {
             tenantId = "manual";
+        } else {
+            principal = oidcSession.getIdToken();
         }
         oidcHandler.loginWithOidcSession(tenantId, RenardeSecurity.getUserId(principal));
     }


### PR DESCRIPTION
In RenardeOidcController.loginUsingOidc, the code always pulls the principal from:

[JWTCallerPrincipal principal = (JWTCallerPrincipal) identity.getPrincipal();](https://github.com/quarkiverse/quarkus-renarde/blob/e5361314dd24d6d3bcdb3bf66f3e85148ed1d7c8/oidc/src/main/java/io/quarkiverse/renarde/oidc/impl/RenardeOidcController.java#L33)

```java
    @Path("login-{provider}")
    @Authenticated
    public void loginUsingOidc(@RestPath String provider) {
        // this can be called if we're authenticated on OIDC but the user didn't go through
        // with completion
        JWTCallerPrincipal principal = (JWTCallerPrincipal) identity.getPrincipal();
        String tenantId = oidcSession.getTenantId();
        if (tenantId == null) {
            tenantId = "manual";
        }
        oidcHandler.loginWithOidcSession(tenantId, RenardeSecurity.getUserId(principal));
    }
```

When a user is logged in via a QuarkusUser cookie, identity.getPrincipal() returns the QuarkusUser-backed principal.
However, if an OIDC session (oidcSession) is active, this logic produces incorrect behavior: the controller continues using the QuarkusUser principal instead of the OIDC ID token.

This causes RenardeSecurity.getUserId(principal) to return the local-database user ID rather than the upstream OIDC provider's user ID (e.g., a Google sub claim).


