### PR TITLE
  Fix login and cookie paths to respect quarkus.http.root-path

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/renarde/deployment/RenardeProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/renarde/deployment/RenardeProcessor.java
@@ -128,6 +128,7 @@ import io.quarkus.runtime.StartupEvent;
 import io.quarkus.smallrye.jwt.deployment.GenerateEncryptedDevModeJwtKeysBuildItem;
 import io.quarkus.smallrye.jwt.deployment.GeneratePersistentDevModeJwtKeysBuildItem;
 import io.quarkus.smallrye.jwt.runtime.auth.JWTAuthMechanism;
+import io.quarkus.vertx.http.deployment.HttpRootPathBuildItem;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 
@@ -766,7 +767,8 @@ public class RenardeProcessor {
     @Record(ExecutionTime.STATIC_INIT)
     void configureLoginPage(RenardeRecorder recorder,
             LoginPageBuildItem loginPageBuildItem,
-            BeanContainerBuildItem beanContainerBuildItem) {
+            BeanContainerBuildItem beanContainerBuildItem,
+            HttpRootPathBuildItem httpRootPath) {
         String loginPage;
         if (loginPageBuildItem != null) {
             loginPage = loginPageBuildItem.uri;
@@ -794,7 +796,32 @@ public class RenardeProcessor {
                 loginPage = "/";
             }
         }
+        loginPage = prependRootPath(httpRootPath.getRootPath(), loginPage);
         recorder.configureLoginPage(beanContainerBuildItem.getValue(), loginPage);
+    }
+
+    /**
+     * Prepends the HTTP root path to the given path.
+     * <p>
+     * If the root path is {@code "/"}, the path is returned unchanged.
+     * If the given path is {@code "/"}, only the root path is returned.
+     * Otherwise, the root path is prepended to the path, taking care to avoid double slashes.
+     *
+     * @param rootPath the HTTP root path (e.g. {@code "/my-app"} or {@code "/"})
+     * @param path the path to prepend the root path to (e.g. {@code "/_renarde/security/login"})
+     * @return the path with the root path prepended (e.g. {@code "/my-app/_renarde/security/login"})
+     */
+    private static String prependRootPath(String rootPath, String path) {
+        if (rootPath.equals("/")) {
+            return path;
+        }
+        if (rootPath.endsWith("/")) {
+            rootPath = rootPath.substring(0, rootPath.length() - 1);
+        }
+        if (path.equals("/")) {
+            return rootPath;
+        }
+        return rootPath + path;
     }
 
     @BuildStep

--- a/deployment/src/test/java/io/quarkiverse/renarde/test/LoginControllerWithPrefixTest.java
+++ b/deployment/src/test/java/io/quarkiverse/renarde/test/LoginControllerWithPrefixTest.java
@@ -1,0 +1,177 @@
+package io.quarkiverse.renarde.test;
+
+import java.net.URL;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.Path;
+
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.renarde.Controller;
+import io.quarkiverse.renarde.security.RenardeUser;
+import io.quarkiverse.renarde.security.RenardeUserProvider;
+import io.quarkiverse.renarde.security.RenardeUserWithPassword;
+import io.quarkus.elytron.security.common.BcryptUtil;
+import io.quarkus.security.Authenticated;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.restassured.RestAssured;
+
+public class LoginControllerWithPrefixTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(MyUser.class, MyUserProvider.class, MyController.class)
+                    .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml"))
+            .overrideConfigKey("quarkus.http.root-path", "/my-app");
+
+    @TestHTTPResource
+    URL url;
+
+    @Test
+    public void testUnProtectedPage() {
+        // RestAssured auto-prepends /my-app (the root path)
+        RestAssured
+                .given()
+                .redirects().follow(false)
+                .when()
+                .get("/unprotected").then()
+                .statusCode(200)
+                .body(Matchers.is("OK"));
+    }
+
+    @Test
+    public void testProtectedPageWithoutLogin() {
+        RestAssured
+                .given()
+                .redirects().follow(false)
+                .when()
+                .get("/protected").then()
+                .statusCode(302)
+                .header("Location", url + "_renarde/security/login");
+    }
+
+    @Test
+    public void testSuccessfulLoginPage() {
+        RestAssured
+                .given()
+                .redirects().follow(false)
+                .when()
+                .param("username", "user")
+                .param("password", "secret")
+                .post("/_renarde/security/login").then()
+                .statusCode(303)
+                .cookie("QuarkusUser", Matchers.notNullValue())
+                .header("Location", url.toString());
+    }
+
+    @Test
+    public void testSuccessfulLoginPageCookiePath() {
+        List<String> cookieHeaders = RestAssured
+                .given()
+                .redirects().follow(false)
+                .when()
+                .param("username", "user")
+                .param("password", "secret")
+                .post("/_renarde/security/login").then()
+                .statusCode(303)
+                .extract().headers().getValues("Set-Cookie");
+        boolean found = cookieHeaders.stream()
+                .anyMatch(h -> h.startsWith("QuarkusUser=") && h.contains("Path=/my-app"));
+        Assertions.assertTrue(found,
+                "QuarkusUser cookie should have Path=/my-app but Set-Cookie headers were: " + cookieHeaders);
+    }
+
+    @Test
+    public void testFailedLoginPage() {
+        Map<String, String> cookies = RestAssured
+                .given()
+                .redirects().follow(false)
+                .when()
+                .param("username", "unknown")
+                .param("password", "secret")
+                .post("/_renarde/security/login").then()
+                .statusCode(303)
+                .header("Location", url + "_renarde/security/login")
+                .extract().cookies();
+        Assertions.assertNull(cookies.get("QuarkusUser"));
+    }
+
+    @Test
+    public void testLogoutRedirectsToRootPath() {
+        RestAssured
+                .given()
+                .redirects().follow(false)
+                .when()
+                .get("/_renarde/security/logout").then()
+                .statusCode(303)
+                .header("Location", url.toString());
+    }
+
+    public static class MyController extends Controller {
+        @Authenticated
+        @Path("/protected")
+        public String prot() {
+            return "OK";
+        }
+
+        @Path("/unprotected")
+        public String unprot() {
+            return "OK";
+        }
+    }
+
+    public static class MyUser implements RenardeUserWithPassword {
+
+        String username;
+        String password;
+
+        @Override
+        public Set<String> roles() {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public String userId() {
+            return username;
+        }
+
+        @Override
+        public boolean registered() {
+            return true;
+        }
+
+        @Override
+        public String password() {
+            return password;
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class MyUserProvider implements RenardeUserProvider {
+
+        @Override
+        public RenardeUser findUser(String tenantId, String authId) {
+            if (authId.equals("user")) {
+                MyUser user = new MyUser();
+                user.username = authId;
+                user.password = BcryptUtil.bcryptHash("secret");
+                return user;
+            }
+            return null;
+        }
+
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/renarde/test/LoginControllerWithPrefixUnscopedCookieTest.java
+++ b/deployment/src/test/java/io/quarkiverse/renarde/test/LoginControllerWithPrefixUnscopedCookieTest.java
@@ -1,0 +1,118 @@
+package io.quarkiverse.renarde.test;
+
+import java.net.URL;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.Path;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.renarde.Controller;
+import io.quarkiverse.renarde.security.RenardeUser;
+import io.quarkiverse.renarde.security.RenardeUserProvider;
+import io.quarkiverse.renarde.security.RenardeUserWithPassword;
+import io.quarkus.elytron.security.common.BcryptUtil;
+import io.quarkus.security.Authenticated;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.restassured.RestAssured;
+
+public class LoginControllerWithPrefixUnscopedCookieTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(MyUser.class, MyUserProvider.class, MyController.class)
+                    .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml"))
+            .overrideConfigKey("quarkus.http.root-path", "/my-app")
+            .overrideConfigKey("quarkus.renarde.auth.scope-cookies-to-root-path", "false");
+
+    @TestHTTPResource
+    URL url;
+
+    @Test
+    public void testLoginCookiePathIsRoot() {
+        List<String> cookieHeaders = RestAssured
+                .given()
+                .redirects().follow(false)
+                .when()
+                .param("username", "user")
+                .param("password", "secret")
+                .post("/_renarde/security/login").then()
+                .statusCode(303)
+                .extract().headers().getValues("Set-Cookie");
+        boolean found = cookieHeaders.stream()
+                .anyMatch(h -> h.startsWith("QuarkusUser=") && h.contains("Path=/"));
+        // Make sure it's NOT scoped to /my-app
+        boolean wrongPath = cookieHeaders.stream()
+                .anyMatch(h -> h.startsWith("QuarkusUser=") && h.contains("Path=/my-app"));
+        Assertions.assertTrue(found,
+                "QuarkusUser cookie should have Path=/ but Set-Cookie headers were: " + cookieHeaders);
+        Assertions.assertFalse(wrongPath,
+                "QuarkusUser cookie should NOT have Path=/my-app but Set-Cookie headers were: " + cookieHeaders);
+    }
+
+    public static class MyController extends Controller {
+        @Authenticated
+        @Path("/protected")
+        public String prot() {
+            return "OK";
+        }
+
+        @Path("/unprotected")
+        public String unprot() {
+            return "OK";
+        }
+    }
+
+    public static class MyUser implements RenardeUserWithPassword {
+
+        String username;
+        String password;
+
+        @Override
+        public Set<String> roles() {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public String userId() {
+            return username;
+        }
+
+        @Override
+        public boolean registered() {
+            return true;
+        }
+
+        @Override
+        public String password() {
+            return password;
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class MyUserProvider implements RenardeUserProvider {
+
+        @Override
+        public RenardeUser findUser(String tenantId, String authId) {
+            if (authId.equals("user")) {
+                MyUser user = new MyUser();
+                user.username = authId;
+                user.password = BcryptUtil.bcryptHash("secret");
+                return user;
+            }
+            return null;
+        }
+
+    }
+}

--- a/docs/modules/ROOT/pages/includes/quarkus-renarde.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-renarde.adoc
@@ -49,6 +49,27 @@ endif::add-copy-button-to-env-var[]
 |string
 |`+++quarkus-redirect-location+++`
 
+a|icon:lock[title=Fixed at build time] [[quarkus-renarde_quarkus-renarde-auth-scope-cookies-to-root-path]] [.property-path]##link:#quarkus-renarde_quarkus-renarde-auth-scope-cookies-to-root-path[`quarkus.renarde.auth.scope-cookies-to-root-path`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.renarde.auth.scope-cookies-to-root-path+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+When true, authentication cookies use `quarkus.http.root-path` as their path. When false, cookies use `"/"`.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_RENARDE_AUTH_SCOPE_COOKIES_TO_ROOT_PATH+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_RENARDE_AUTH_SCOPE_COOKIES_TO_ROOT_PATH+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
 a|icon:lock[title=Fixed at build time] [[quarkus-renarde_quarkus-renarde-auth-location-cookie]] [.property-path]##link:#quarkus-renarde_quarkus-renarde-auth-location-cookie[[.line-through]#`quarkus.renarde.auth.location-cookie`#]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.renarde.auth.location-cookie+++[]

--- a/docs/modules/ROOT/pages/includes/quarkus-renarde_quarkus.renarde.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-renarde_quarkus.renarde.adoc
@@ -49,6 +49,27 @@ endif::add-copy-button-to-env-var[]
 |string
 |`+++quarkus-redirect-location+++`
 
+a|icon:lock[title=Fixed at build time] [[quarkus-renarde_quarkus-renarde-auth-scope-cookies-to-root-path]] [.property-path]##link:#quarkus-renarde_quarkus-renarde-auth-scope-cookies-to-root-path[`quarkus.renarde.auth.scope-cookies-to-root-path`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.renarde.auth.scope-cookies-to-root-path+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+When true, authentication cookies use `quarkus.http.root-path` as their path. When false, cookies use `"/"`.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_RENARDE_AUTH_SCOPE_COOKIES_TO_ROOT_PATH+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_RENARDE_AUTH_SCOPE_COOKIES_TO_ROOT_PATH+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
 a|icon:lock[title=Fixed at build time] [[quarkus-renarde_quarkus-renarde-auth-location-cookie]] [.property-path]##link:#quarkus-renarde_quarkus-renarde-auth-location-cookie[[.line-through]#`quarkus.renarde.auth.location-cookie`#]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.renarde.auth.location-cookie+++[]

--- a/runtime/src/main/java/io/quarkiverse/renarde/configuration/RenardeConfig.java
+++ b/runtime/src/main/java/io/quarkiverse/renarde/configuration/RenardeConfig.java
@@ -45,6 +45,13 @@ public interface RenardeConfig {
         Redirect redirect();
 
         /**
+         * When true, authentication cookies use {@code quarkus.http.root-path} as their path.
+         * When false, cookies use {@code "/"}.
+         */
+        @WithDefault("true")
+        boolean scopeCookiesToRootPath();
+
+        /**
          * Please do not use and use <code>quarkus.renarde.auth.redirect.cookie</code> instead.
          *
          * @deprecated use {@link Redirect#cookie()}

--- a/runtime/src/main/java/io/quarkiverse/renarde/util/RenardeJWTAuthMechanism.java
+++ b/runtime/src/main/java/io/quarkiverse/renarde/util/RenardeJWTAuthMechanism.java
@@ -12,6 +12,7 @@ import org.jboss.logging.Logger;
 
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.quarkiverse.renarde.configuration.RenardeConfig;
+import io.quarkiverse.renarde.configuration.RenardeConfig.RenardeAuthConfig;
 import io.quarkiverse.renarde.impl.RenardeConfigBean;
 import io.quarkus.qute.TemplateGlobal;
 import io.quarkus.smallrye.jwt.runtime.auth.JWTAuthMechanism;
@@ -45,6 +46,12 @@ public class RenardeJWTAuthMechanism extends JWTAuthMechanism {
     @ConfigProperty(name = "quarkus.renarde.auth.redirect.type")
     RenardeConfig.RenardeAuthConfig.Redirect.Type redirectType;
 
+    @Inject
+    RenardeConfig renardeConfig;
+
+    @ConfigProperty(name = "quarkus.http.root-path", defaultValue = "/")
+    String rootPath;
+
     // for CDI proxy
     RenardeJWTAuthMechanism() {
         this(null);
@@ -61,7 +68,7 @@ public class RenardeJWTAuthMechanism extends JWTAuthMechanism {
 
     protected void storeInitialLocation(final RoutingContext exchange) {
         exchange.response().addCookie(Cookie.cookie(locationCookie, exchange.request().absoluteURI())
-                .setPath("/").setSecure(exchange.request().isSSL()));
+                .setPath(renardeConfig.auth().scopeCookiesToRootPath() ? rootPath : "/").setSecure(exchange.request().isSSL()));
     }
 
     static Uni<ChallengeData> getRedirect(final RoutingContext exchange, final String location) {

--- a/security/src/main/java/io/quarkiverse/renarde/security/RenardeSecurity.java
+++ b/security/src/main/java/io/quarkiverse/renarde/security/RenardeSecurity.java
@@ -47,6 +47,9 @@ public class RenardeSecurity {
     @ConfigProperty(name = "quarkus.oidc.authentication.cookie-suffix", defaultValue = "q_session")
     String oidcCookie;
 
+    @ConfigProperty(name = "quarkus.http.root-path", defaultValue = "/")
+    String rootPath;
+
     @ConfigProperty(name = "quarkus.renarde.auth.redirect.cookie")
     String locationCookie;
 
@@ -91,7 +94,7 @@ public class RenardeSecurity {
         // FIXME: expiry, auto-refresh?
         return new NewCookie.Builder(jwtCookie)
                 .value(token)
-                .path("/")
+                .path(cookiePath())
                 .sameSite(SameSite.LAX)
                 .httpOnly(true)
                 .build();
@@ -140,6 +143,8 @@ public class RenardeSecurity {
 
     public Response makeLogoutResponse() {
         try {
+            // Use "/" rather than the root-path directly, because Response.seeOther()
+            // already resolves relative URIs against quarkus.http.root-path
             return this.makeLogoutResponse(new URI("/"));
         } catch (URISyntaxException e) {
             // can't happen
@@ -241,15 +246,20 @@ public class RenardeSecurity {
     }
 
     private NewCookie saveURICookie() {
-        return new NewCookie.Builder(locationCookie).path("/").value(request.absoluteURI()).secure(request.isSSL()).build();
+        return new NewCookie.Builder(locationCookie).path(cookiePath()).value(request.absoluteURI())
+                .secure(request.isSSL()).build();
     }
 
     public NewCookie invalidateCookie(String cookieName) {
-        return new NewCookie.Builder(cookieName).path("/").maxAge(0).build();
+        return new NewCookie.Builder(cookieName).path(cookiePath()).maxAge(0).build();
     }
 
     public boolean hasUserCookie() {
         return request.getCookie(jwtCookie) != null;
+    }
+
+    private String cookiePath() {
+        return renardeConfig.auth().scopeCookiesToRootPath() ? rootPath : "/";
     }
 
 }


### PR DESCRIPTION
## Summary

  Fixes #308

  1. **Login redirect** — resolve login page path relative to `quarkus.http.root-path` so it redirects to `/my-app/login` instead of `/login`
  2. **Logout redirect** — already works correctly (`Response.seeOther()` resolves relative URIs against root path), no change needed
  3. **Cookie path** — add `quarkus.renarde.auth.scope-cookies-to-root-path` (boolean, default `true`) to scope authentication cookies to `quarkus.http.root-path` instead of `/`, preventing
   cookie leaks across apps on the same domain. Set to `false` to keep the old `Path=/` behavior.

  ## Test plan

  - `LoginControllerTest` — default root path (`/`)
  - `LoginControllerWithPrefixTest` — root path `/my-app`: login redirect and cookie `Path=/my-app`
  - `LoginControllerWithPrefixUnscopedCookieTest` — `scope-cookies-to-root-path=false` → `Path=/`